### PR TITLE
Add context management for API users

### DIFF
--- a/deployment/dev-base-envs.yml
+++ b/deployment/dev-base-envs.yml
@@ -1,0 +1,7 @@
+version: "3.1"
+
+services:
+    schema-api:
+      environment:
+        SCHEMA_API_USE_AUTH: Yes
+        SCHEMA_API_USE_FILES: Yes

--- a/deployment/dev-base.yml
+++ b/deployment/dev-base.yml
@@ -6,10 +6,11 @@ services:
         - runserver
         - 0.0.0.0:80
       image: schema-api-dev
+      user: ${MY_UID}:${MY_GID}
       build:
         context: ..
         dockerfile: deployment/dev.Dockerfile
       ports:
         - "8080:80"
       volumes:
-        - ../:/schema-api/
+        - ../schema-api:/schema-api/

--- a/deployment/dev-makemigrations.yml
+++ b/deployment/dev-makemigrations.yml
@@ -1,0 +1,6 @@
+version: "3.1"
+
+services:
+    schema-api:
+      command:
+        - makemigrations

--- a/deployment/dev-migrate.yml
+++ b/deployment/dev-migrate.yml
@@ -1,0 +1,6 @@
+version: "3.1"
+
+services:
+    schema-api:
+      command:
+        - migrate

--- a/schema-api/api/services.py
+++ b/schema-api/api/services.py
@@ -19,6 +19,21 @@ from quotas.services import QuotasService
 from util.exceptions import ApplicationError, ApplicationErrorHelper, ApplicationNotFoundError
 
 
+class UserContextService:
+
+    def __init__(self, auth_entity: AuthEntity):
+        self.auth_entity = auth_entity
+
+    def list_contexts(self) -> Iterable[Context]:
+        return self.auth_entity.contexts.all()
+
+    def retrieve_context(self, name: str) -> Context:
+        try:
+            return self.auth_entity.contexts.get(name=name)
+        except Context.DoesNotExist as dne:
+            raise ApplicationNotFoundError from dne
+
+
 class TaskService:
 
     def __init__(self, context=None, auth_entity=None):
@@ -149,7 +164,7 @@ class TaskService:
         ]
         return executors_stderr
 
-    def get_tasks(self)->QuerySet[Task]:
+    def get_tasks(self) -> QuerySet[Task]:
         return Task.objects.filter(context=self.context)
 
 

--- a/schema-api/api/tests.py
+++ b/schema-api/api/tests.py
@@ -1,3 +1,0 @@
-from django.test import TestCase
-
-# Create your tests here.

--- a/schema-api/api/tests/test_api.py
+++ b/schema-api/api/tests/test_api.py
@@ -187,3 +187,99 @@ class UserContextDetailsAPITestCase(APITestCase):
         url = reverse('user-context-details', args=['context2'])
         response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+
+# Tests for temporary endpoint - expected to be removed in the future
+class UserContextInfoAPIViewTestCase(APITestCase):
+
+    @classmethod
+    def setUpTestData(cls):
+        app_service = AuthEntity.objects.create(username='as', entity_type=AuthEntityType.APPLICATION_SERVICE)
+        cls.contexts = {
+            'context0': Context.objects.create(owner=app_service, name='context0'),
+            'context1': Context.objects.create(owner=app_service, name='context1'),
+            'context2': Context.objects.create(owner=app_service, name='context2')
+        }
+        cls.user0 = AuthEntity.objects.create(username='user0', parent=app_service)
+        cls.user1 = AuthEntity.objects.create(username='user1', parent=app_service)
+        cls.user2 = AuthEntity.objects.create(username='user2', parent=app_service, is_active=False)
+        Participation.objects.create(user=cls.user0, context=cls.contexts['context0'])
+        Participation.objects.create(user=cls.user0, context=cls.contexts['context1'])
+        Participation.objects.create(user=cls.user1, context=cls.contexts['context2'])
+
+        p = Participation.objects.create(user=cls.user1, context=cls.contexts['context0'])
+        Participation.objects.create(user=cls.user2, context=cls.contexts['context0'])
+        ats = ApiTokenService(cls.user0, cls.contexts['context0'])
+        cls.u0c0_key, _ = ats.issue_token(duration='1d', title='valid')
+        cls.u0c0_key_expired, key = ats.issue_token(duration='1d', title='expired',
+                                                    created=timezone.now() - timedelta(days=2),
+                                                    expiry=timezone.now() - timedelta(days=1))
+        cls.u0c0_key_inactive, _ = ats.issue_token(duration='1d', is_active=False, title='inactive')
+        ats = ApiTokenService(cls.user1, cls.contexts['context0'])
+        cls.u1c0_key, _ = ats.issue_token(duration='1d')
+        ats = ApiTokenService(cls.user2, cls.contexts['context0'])
+        cls.u2c0_key, _ = ats.issue_token(duration='1d')
+        ats = ApiTokenService(app_service)
+        cls.svc_key, _ = ats.issue_token(duration='1d')
+
+        p.delete()
+
+    # Test API permissions
+    def test_poll_api_with_no_credentials_is_forbidden(self):
+        self.client.credentials()
+        url = reverse('user-context-info')
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_poll_api_with_inactive_api_key_is_forbidden(self):
+        self.client.credentials(HTTP_AUTHORIZATION='Bearer ' + self.u0c0_key_inactive)
+        url = reverse('user-context-info')
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_poll_api_with_expired_api_key_is_forbidden(self):
+        self.client.credentials(HTTP_AUTHORIZATION='Bearer ' + self.u0c0_key_expired)
+        url = reverse('user-context-info')
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_poll_api_with_inactive_user_is_forbidden(self):
+        self.client.credentials(HTTP_AUTHORIZATION='Bearer ' + self.u2c0_key)
+        url = reverse('user-context-info')
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_poll_api_with_stale_credentials_of_deleted_participation_is_forbidden(self):
+        self.client.credentials(HTTP_AUTHORIZATION='Bearer ' + self.u1c0_key)
+        url = reverse('user-context-info')
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_poll_api_with_application_service_credentials_is_forbidden(self):
+        self.client.credentials(HTTP_AUTHORIZATION='Bearer ' + self.svc_key)
+        url = reverse('user-context-info')
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_retrieve_context_info_returns_context_details(self):
+        self.client.credentials(HTTP_AUTHORIZATION='Bearer ' + self.u0c0_key)
+        url = reverse('user-context-info')
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn('name', response.data)
+        self.assertEqual(response.data['name'], 'context0')
+        self.assertIn('users', response.data)
+        self.assertEqual(
+            [
+                {
+                    'username': 'user0',
+                    'is_active': True
+                },
+                {
+                    'username': 'user2',
+                    'is_active': False
+                }
+            ],
+            response.data['users']
+        )
+        self.assertIn('quotas', response.data)

--- a/schema-api/api/tests/test_api.py
+++ b/schema-api/api/tests/test_api.py
@@ -1,0 +1,189 @@
+from datetime import datetime, timedelta
+
+from django.urls import reverse
+from django.utils import timezone
+from rest_framework import status
+from rest_framework.test import APITestCase, APIClient
+
+from api.models import Context, Participation
+from api_auth.constants import AuthEntityType
+from api_auth.models import AuthEntity, ApiToken
+from api_auth.services import ApiTokenService
+
+
+class UserContextsAPITestCase(APITestCase):
+
+    @classmethod
+    def setUpTestData(cls):
+        app_service = AuthEntity.objects.create(username='as', entity_type=AuthEntityType.APPLICATION_SERVICE)
+        cls.contexts = {
+            'context0': Context.objects.create(owner=app_service, name='context0'),
+            'context1': Context.objects.create(owner=app_service, name='context1'),
+            'context2': Context.objects.create(owner=app_service, name='context2')
+        }
+        cls.user0 = AuthEntity.objects.create(username='user0', parent=app_service)
+        cls.user1 = AuthEntity.objects.create(username='user1', parent=app_service)
+        cls.user2 = AuthEntity.objects.create(username='user2', parent=app_service, is_active=False)
+
+        Participation.objects.create(user=cls.user0, context=cls.contexts['context0'])
+        Participation.objects.create(user=cls.user0, context=cls.contexts['context1'])
+        Participation.objects.create(user=cls.user1, context=cls.contexts['context2'])
+        p = Participation.objects.create(user=cls.user1, context=cls.contexts['context0'])
+        Participation.objects.create(user=cls.user2, context=cls.contexts['context0'])
+
+        ats = ApiTokenService(cls.user0, cls.contexts['context0'])
+        cls.u0c0_key, _ = ats.issue_token(duration='1d', title='valid')
+        cls.u0c0_key_expired, key = ats.issue_token(duration='1d', title='expired',
+                                                    created=timezone.now() - timedelta(days=2),
+                                                    expiry=timezone.now() - timedelta(days=1))
+        cls.u0c0_key_inactive, _ = ats.issue_token(duration='1d', is_active=False, title='inactive')
+        ats = ApiTokenService(cls.user1, cls.contexts['context0'])
+        cls.u1c0_key, _ = ats.issue_token(duration='1d')
+        ats = ApiTokenService(cls.user2, cls.contexts['context0'])
+        cls.u2c0_key, _ = ats.issue_token(duration='1d')
+        ats = ApiTokenService(app_service)
+        cls.svc_key, _ = ats.issue_token(duration='1d')
+
+        p.delete()
+
+    # Test API permissions
+    def test_poll_api_with_no_credentials_is_forbidden(self):
+        self.client.credentials()
+        url = reverse('user-contexts')
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_poll_api_with_inactive_api_key_is_forbidden(self):
+        self.client.credentials(HTTP_AUTHORIZATION='Bearer ' + self.u0c0_key_inactive)
+        url = reverse('user-contexts')
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_poll_api_with_expired_api_key_is_forbidden(self):
+        self.client.credentials(HTTP_AUTHORIZATION='Bearer ' + self.u0c0_key_expired)
+        url = reverse('user-contexts')
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_poll_api_with_inactive_user_is_forbidden(self):
+        self.client.credentials(HTTP_AUTHORIZATION='Bearer ' + self.u2c0_key)
+        url = reverse('user-contexts')
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_poll_api_with_stale_credentials_of_deleted_participation_is_forbidden(self):
+        self.client.credentials(HTTP_AUTHORIZATION='Bearer ' + self.u1c0_key)
+        url = reverse('user-contexts')
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_list_contexts_for_user_returns_user_related_contexts(self):
+        self.client.credentials(HTTP_AUTHORIZATION='Bearer ' + self.u0c0_key)
+        url = reverse('user-contexts')
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 2)
+        self.assertIn(
+            {'name': 'context0'}, response.data
+        )
+        self.assertIn(
+            {'name': 'context1'}, response.data
+        )
+
+    # Inapplicable for now, in order to have an API key to call the API, a user must have issued one base on a context
+    # that he participates at the time of the request
+    # def test_list_contexts_for_user_returns_empty_list_when_user_has_no_context(self):
+    #     pass
+
+
+class UserContextDetailsAPITestCase(APITestCase):
+
+    @classmethod
+    def setUpTestData(cls):
+        app_service = AuthEntity.objects.create(username='as', entity_type=AuthEntityType.APPLICATION_SERVICE)
+        cls.contexts = {
+            'context0': Context.objects.create(owner=app_service, name='context0'),
+            'context1': Context.objects.create(owner=app_service, name='context1'),
+            'context2': Context.objects.create(owner=app_service, name='context2')
+        }
+        cls.user0 = AuthEntity.objects.create(username='user0', parent=app_service)
+        cls.user1 = AuthEntity.objects.create(username='user1', parent=app_service)
+        cls.user2 = AuthEntity.objects.create(username='user2', parent=app_service, is_active=False)
+        Participation.objects.create(user=cls.user0, context=cls.contexts['context0'])
+        Participation.objects.create(user=cls.user0, context=cls.contexts['context1'])
+        Participation.objects.create(user=cls.user1, context=cls.contexts['context2'])
+
+        p = Participation.objects.create(user=cls.user1, context=cls.contexts['context0'])
+        Participation.objects.create(user=cls.user2, context=cls.contexts['context0'])
+        ats = ApiTokenService(cls.user0, cls.contexts['context0'])
+        cls.u0c0_key, _ = ats.issue_token(duration='1d', title='valid')
+        cls.u0c0_key_expired, key = ats.issue_token(duration='1d', title='expired',
+                                                    created=timezone.now() - timedelta(days=2),
+                                                    expiry=timezone.now() - timedelta(days=1))
+        cls.u0c0_key_inactive, _ = ats.issue_token(duration='1d', is_active=False, title='inactive')
+        ats = ApiTokenService(cls.user1, cls.contexts['context0'])
+        cls.u1c0_key, _ = ats.issue_token(duration='1d')
+        ats = ApiTokenService(cls.user2, cls.contexts['context0'])
+        cls.u2c0_key, _ = ats.issue_token(duration='1d')
+        ats = ApiTokenService(app_service)
+        cls.svc_key, _ = ats.issue_token(duration='1d')
+
+        p.delete()
+
+    # Test API permissions
+    def test_poll_api_with_no_credentials_is_forbidden(self):
+        self.client.credentials()
+        url = reverse('user-context-details', args=['name'])
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_poll_api_with_inactive_api_key_is_forbidden(self):
+        self.client.credentials(HTTP_AUTHORIZATION='Bearer ' + self.u0c0_key_inactive)
+        url = reverse('user-context-details', args=['name'])
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_poll_api_with_expired_api_key_is_forbidden(self):
+        self.client.credentials(HTTP_AUTHORIZATION='Bearer ' + self.u0c0_key_expired)
+        url = reverse('user-context-details', args=['name'])
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_poll_api_with_inactive_user_is_forbidden(self):
+        self.client.credentials(HTTP_AUTHORIZATION='Bearer ' + self.u2c0_key)
+        url = reverse('user-context-details', args=['name'])
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_poll_api_with_stale_credentials_of_deleted_participation_is_forbidden(self):
+        self.client.credentials(HTTP_AUTHORIZATION='Bearer ' + self.u1c0_key)
+        url = reverse('user-context-details', args=['name'])
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_retrieve_context_returns_context_details(self):
+        self.client.credentials(HTTP_AUTHORIZATION='Bearer ' + self.u0c0_key)
+        url = reverse('user-context-details', args=['context0'])
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn('users', response.data)
+        self.assertEqual(
+            [
+                {
+                    'username': 'user0',
+                    'is_active': True
+                },
+                {
+                    'username': 'user2',
+                    'is_active': False
+                }
+            ],
+            response.data['users']
+        )
+        self.assertIn('quotas', response.data)
+
+    def test_retrieve_context_with_invalid_context_name_raises_404_not_found(self):
+        self.client.credentials(HTTP_AUTHORIZATION='Bearer ' + self.u0c0_key)
+        url = reverse('user-context-details', args=['context2'])
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)

--- a/schema-api/api/tests/test_services.py
+++ b/schema-api/api/tests/test_services.py
@@ -1,0 +1,46 @@
+from django.test import TestCase
+
+from api.models import Context, Participation
+from api.services import UserContextService
+from api_auth.constants import AuthEntityType
+from api_auth.models import AuthEntity
+from util.exceptions import ApplicationError, ApplicationNotFoundError
+
+
+class UserContextTestCase(TestCase):
+
+    @classmethod
+    def setUpTestData(cls):
+        app_service = AuthEntity.objects.create(username='as', entity_type=AuthEntityType.APPLICATION_SERVICE)
+        cls.contexts = {
+            'context0': Context.objects.create(owner=app_service, name='context0'),
+            'context1': Context.objects.create(owner=app_service, name='context1'),
+            'context2': Context.objects.create(owner=app_service, name='context2')
+        }
+        cls.user0 = AuthEntity.objects.create(username='user0', parent=app_service)
+        Participation.objects.create(user=cls.user0, context=cls.contexts['context0'])
+        Participation.objects.create(user=cls.user0, context=cls.contexts['context1'])
+        cls.user1 = AuthEntity.objects.create(username='user1', parent=app_service)
+
+    def test_list_contexts_returns_only_users_contexts(self):
+        ucs = UserContextService(self.user0)
+        contexts = ucs.list_contexts()
+        expected = [self.contexts['context0'], self.contexts['context1']]
+        self.assertEquals(len([c for c in contexts]), len(expected))
+        for c in contexts:
+            self.assertIn(c, expected)
+
+    def test_list_contexts_returns_no_contexts_if_user_not_in_any_context(self):
+        ucs = UserContextService(self.user1)
+        contexts = ucs.list_contexts()
+        self.assertEquals(len([c for c in contexts]), 0)
+
+    def test_get_context_returns_context_referenced_by_provided_name(self):
+        ucs = UserContextService(self.user0)
+        context = ucs.retrieve_context('context1')
+        self.assertEquals(context, self.contexts['context1'])
+
+    def test_get_context_raises_application_not_found_error_on_no_match(self):
+        ucs = UserContextService(self.user0)
+        with self.assertRaises(ApplicationNotFoundError):
+            ucs.retrieve_context(3)

--- a/schema-api/api/tests/test_services.py
+++ b/schema-api/api/tests/test_services.py
@@ -26,19 +26,19 @@ class UserContextTestCase(TestCase):
         ucs = UserContextService(self.user0)
         contexts = ucs.list_contexts()
         expected = [self.contexts['context0'], self.contexts['context1']]
-        self.assertEquals(len([c for c in contexts]), len(expected))
+        self.assertEqual(len([c for c in contexts]), len(expected))
         for c in contexts:
             self.assertIn(c, expected)
 
     def test_list_contexts_returns_no_contexts_if_user_not_in_any_context(self):
         ucs = UserContextService(self.user1)
         contexts = ucs.list_contexts()
-        self.assertEquals(len([c for c in contexts]), 0)
+        self.assertEqual(len([c for c in contexts]), 0)
 
     def test_get_context_returns_context_referenced_by_provided_name(self):
         ucs = UserContextService(self.user0)
         context = ucs.retrieve_context('context1')
-        self.assertEquals(context, self.contexts['context1'])
+        self.assertEqual(context, self.contexts['context1'])
 
     def test_get_context_raises_application_not_found_error_on_no_match(self):
         ucs = UserContextService(self.user0)

--- a/schema-api/api/tests/test_urls.py
+++ b/schema-api/api/tests/test_urls.py
@@ -1,0 +1,23 @@
+from django.test import TestCase
+from django.urls import reverse, resolve
+
+from api_auth.views import ContextsAPIView, ContextDetailsAPIView
+
+
+class ApiUrlsCase(TestCase):
+
+    def test_reverse_user_contexts_is_expected_url(self):
+        expected = '/api/contexts'
+        self.assertEquals(reverse('user-contexts'),expected)
+
+    def test_reverse_user_context_details_is_expected_url(self):
+        expected = '/api/contexts/name'
+        self.assertEquals(reverse('user-context-details', args=['name']), expected)
+
+    def test_user_contexts_url_routes_to_expected_api_view(self):
+        resolved = resolve('/api/contexts')
+        self.assertEquals(resolved.func.view_class, ContextsAPIView)
+
+    def test_user_context_details_url_routes_to_expected_api_view(self):
+        resolved = resolve('/api/contexts/name')
+        self.assertEquals(resolved.func.view_class, ContextDetailsAPIView)

--- a/schema-api/api/tests/test_urls.py
+++ b/schema-api/api/tests/test_urls.py
@@ -1,6 +1,7 @@
 from django.test import TestCase
 from django.urls import reverse, resolve
 
+from api.views import UserContextInfoAPIView
 from api_auth.views import ContextsAPIView, ContextDetailsAPIView
 
 
@@ -14,6 +15,11 @@ class ApiUrlsCase(TestCase):
         expected = '/api/contexts/name'
         self.assertEqual(reverse('user-context-details', args=['name']), expected)
 
+    # Test for temporary endpoint url - expected to be removed in the future
+    def test_reverse_user_context_info_is_expected_url(self):
+        expected = '/api/context-info'
+        self.assertEqual(reverse('user-context-info'), expected)
+
     def test_user_contexts_url_routes_to_expected_api_view(self):
         resolved = resolve('/api/contexts')
         self.assertEqual(resolved.func.view_class, ContextsAPIView)
@@ -21,3 +27,8 @@ class ApiUrlsCase(TestCase):
     def test_user_context_details_url_routes_to_expected_api_view(self):
         resolved = resolve('/api/contexts/name')
         self.assertEqual(resolved.func.view_class, ContextDetailsAPIView)
+
+    # Test for temporary endpoint url routing - expected to be removed in the future
+    def test_user_context_info_url_routes_to_expected_api_view(self):
+        resolved = resolve('/api/context-info')
+        self.assertEqual(resolved.func.view_class, UserContextInfoAPIView)

--- a/schema-api/api/tests/test_urls.py
+++ b/schema-api/api/tests/test_urls.py
@@ -8,16 +8,16 @@ class ApiUrlsCase(TestCase):
 
     def test_reverse_user_contexts_is_expected_url(self):
         expected = '/api/contexts'
-        self.assertEquals(reverse('user-contexts'),expected)
+        self.assertEqual(reverse('user-contexts'),expected)
 
     def test_reverse_user_context_details_is_expected_url(self):
         expected = '/api/contexts/name'
-        self.assertEquals(reverse('user-context-details', args=['name']), expected)
+        self.assertEqual(reverse('user-context-details', args=['name']), expected)
 
     def test_user_contexts_url_routes_to_expected_api_view(self):
         resolved = resolve('/api/contexts')
-        self.assertEquals(resolved.func.view_class, ContextsAPIView)
+        self.assertEqual(resolved.func.view_class, ContextsAPIView)
 
     def test_user_context_details_url_routes_to_expected_api_view(self):
         resolved = resolve('/api/contexts/name')
-        self.assertEquals(resolved.func.view_class, ContextDetailsAPIView)
+        self.assertEqual(resolved.func.view_class, ContextDetailsAPIView)

--- a/schema-api/api/urls.py
+++ b/schema-api/api/urls.py
@@ -1,7 +1,7 @@
 from django.urls import path
 
 from api.views import UserQuotasAPIView, TasksListCreateAPIView, TaskRetrieveAPIView, TaskStdoutAPIView, \
-    TaskStderrAPIView
+    TaskStderrAPIView, UserContextInfoAPIView
 from api_auth.views import ContextsAPIView, ContextDetailsAPIView
 
 urlpatterns = [
@@ -11,5 +11,7 @@ urlpatterns = [
     path(r'tasks/<uuid:uuid>/stderr', TaskStderrAPIView.as_view(), name='task_stderr'),
     path(r'contexts', ContextsAPIView.as_view(), name='user-contexts'),
     path(r'contexts/<name>', ContextDetailsAPIView.as_view(), name='user-context-details'),
+    # Temporary url - expected to be removed in the future
+    path(r'context-info', UserContextInfoAPIView.as_view(), name='user-context-info'),
     path(r'quotas', UserQuotasAPIView.as_view(), name='user_quotas'),
 ]

--- a/schema-api/api/urls.py
+++ b/schema-api/api/urls.py
@@ -2,11 +2,14 @@ from django.urls import path
 
 from api.views import UserQuotasAPIView, TasksListCreateAPIView, TaskRetrieveAPIView, TaskStdoutAPIView, \
     TaskStderrAPIView
+from api_auth.views import ContextsAPIView, ContextDetailsAPIView
 
 urlpatterns = [
     path(r'tasks', TasksListCreateAPIView.as_view(), name='tasks'),
     path(r'tasks/<uuid:uuid>', TaskRetrieveAPIView.as_view(), name='tasks2'),
     path(r'tasks/<uuid:uuid>/stdout', TaskStdoutAPIView.as_view(), name='task_stdout'),
     path(r'tasks/<uuid:uuid>/stderr', TaskStderrAPIView.as_view(), name='task_stderr'),
+    path(r'contexts', ContextsAPIView.as_view(), name='user-contexts'),
+    path(r'contexts/<name>', ContextDetailsAPIView.as_view(), name='user-context-details'),
     path(r'quotas', UserQuotasAPIView.as_view(), name='user_quotas'),
 ]

--- a/schema-api/api_auth/permissions.py
+++ b/schema-api/api_auth/permissions.py
@@ -45,3 +45,13 @@ class IsContextMember(BasePermission):
         except Participation.DoesNotExist:
             raise False
         return True
+
+
+class IsRelatedToContext(BasePermission):
+
+    def has_permission(self, request, view):
+        is_application_service = IsApplicationService()
+        is_user = IsUser()
+        is_context_member = IsContextMember()
+        return is_application_service.has_permission(request, view) or (
+                is_user.has_permission(request, view) and is_context_member.has_permission(request, view))

--- a/schema-api/config/environments/base.py
+++ b/schema-api/config/environments/base.py
@@ -126,7 +126,9 @@ SPECTACULAR_SETTINGS = {
     'SWAGGER_UI_SETTINGS': {
         'defaultModelsExpandDepth': 10,
         'defaultModelExpandDepth': 10
-    }
+    },
+    "PREPROCESSING_HOOKS": ["documentation.swagger.hooks.preprocessing_filter_spec"],
+
 }
 
 AUTH_USER_MODEL = 'api_auth.AuthEntity'

--- a/schema-api/documentation/swagger/hooks.py
+++ b/schema-api/documentation/swagger/hooks.py
@@ -1,7 +1,10 @@
 def preprocessing_filter_spec(endpoints):
     filtered = []
+    blacklist = ['/api_auth/']
     for (path, path_regex, method, callback) in endpoints:
         # Remove all but DRF API endpoints
-        if path.startswith("/api/"):
+
+        if all(not path.startswith(b) for b in blacklist):
+            print(f'Path: {path}, path_regex: {path_regex}, method: {method}, callback: {callback}')
             filtered.append((path, path_regex, method, callback))
     return filtered

--- a/schema-api/files/models.py
+++ b/schema-api/files/models.py
@@ -1,4 +1,4 @@
-import datetime
+from datetime import datetime
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Dict, Iterable, Optional, TypeVar, Type


### PR DESCRIPTION
Allow users to list their contexts and retrieve detailed information for a specific context. Also add a temporary endpoint that returns detailed information about the context related to an API key (this is expected to be removed when API keys are relieved from the relation with a specific context)