### PR TITLE
Initial changes for new StatusHistoryPoint

### DIFF
--- a/schema-api/api/constants.py
+++ b/schema-api/api/constants.py
@@ -17,6 +17,19 @@ class TaskStatus(models.TextChoices):
     CANCELED = 'CANCELED', 'CANCELED'
 
 
+class _TaskStatus(models.IntegerChoices):
+    UNKNOWN = -1, 'UNKNOWN'
+    SUBMITTED = 0, 'SUBMITTED'
+    APPROVED = 1, 'APPROVED'
+    REJECTED = 2, 'REJECTED'
+    SCHEDULED = 3, 'SCHEDULED'
+    INITIALIZING = 4, 'INITIALIZING'
+    RUNNING = 5, 'RUNNING'
+    COMPLETED = 6, 'COMPLETED'
+    ERROR = 7, 'ERROR'
+    CANCELED = 8, 'CANCELED'
+
+
 class MountPointTypes(models.TextChoices):
     FILE = 'FILE', 'FILE'
     DIRECTORY = 'DIRECTORY', 'DIRECTORY'

--- a/schema-api/api/tests/test_models.py
+++ b/schema-api/api/tests/test_models.py
@@ -1,0 +1,109 @@
+import datetime
+from unittest.mock import patch
+from datetime import datetime as dt
+
+from django.db import IntegrityError
+from django.test import TestCase
+from django.utils import timezone
+
+from api.constants import _TaskStatus
+from api.models import Task, StatusHistoryPoint
+
+
+class StatusHistoryPointTestCase(TestCase):
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.task = Task.objects.create(name='sample-task')
+
+    def test_valid_save_accepts_all_provided_values(self):
+        dt = timezone.now()
+        status = _TaskStatus.SUBMITTED
+        status_history_point = StatusHistoryPoint(task=self.task, created_at=dt, status=status)
+        status_history_point.save()
+        status_history_point.refresh_from_db()
+        self.assertEqual(status_history_point.status, status)
+        self.assertEqual(status_history_point.created_at, dt)
+        self.assertEqual(status_history_point.task, self.task)
+
+    def test_save_without_a_referenced_task_raises_error(self):
+        dt = timezone.now()
+        status = _TaskStatus.SUBMITTED
+        status_history_point = StatusHistoryPoint(created_at=dt, status=status)
+        with self.assertRaises(IntegrityError):
+            status_history_point.save()
+
+    def test_save_with_a_referenced_task_as_none_raises_error(self):
+        dt = timezone.now()
+        status = _TaskStatus.SUBMITTED
+        status_history_point = StatusHistoryPoint(task=None, created_at=dt, status=status)
+        with self.assertRaises(IntegrityError):
+            status_history_point.save()
+
+    def test_save_with_duplicate_referenced_task_works(self):
+        dt = timezone.now()
+        status = _TaskStatus.SUBMITTED
+        status_history_point = StatusHistoryPoint(task=self.task, created_at=dt, status=status)
+        status_history_point.save()
+        status = _TaskStatus.APPROVED
+        status_history_point = StatusHistoryPoint(task=self.task, created_at=dt, status=status)
+        status_history_point.save()
+
+    def test_save_without_created_at_uses_timezone_now_default(self):
+        mocked_datetime = dt(2020, 1, 1, 1, 1, 1, tzinfo=datetime.UTC)
+        status = _TaskStatus.SUBMITTED
+        with patch('django.utils.timezone.now', return_value=mocked_datetime):
+            print(timezone.now())
+            status_history_point = StatusHistoryPoint.objects.create(task=self.task, status=status)
+        print(status_history_point.created_at)
+        self.assertEqual(status_history_point.created_at, mocked_datetime)
+
+    def test_save_with_created_at_as_none_raises_error(self):
+        status = _TaskStatus.SUBMITTED
+        status_history_point = StatusHistoryPoint(task=self.task, created_at=None, status=status)
+        with self.assertRaises(IntegrityError):
+            status_history_point.save()
+
+    def test_save_without_task_status_raises_error(self):
+        dt = timezone.now()
+        status_history_point = StatusHistoryPoint(created_at=dt, task=self.task)
+        with self.assertRaises(IntegrityError):
+            status_history_point.save()
+
+    def test_save_with_task_status_as_none_raises_error(self):
+        dt = timezone.now()
+        status_history_point = StatusHistoryPoint(created_at=dt, task=self.task, status=None)
+        with self.assertRaises(IntegrityError):
+            status_history_point.save()
+
+    def test_save_with_duplicate_task_status_for_same_task_raises_error(self):
+        dt = timezone.now()
+        status = _TaskStatus.SUBMITTED
+        status_history_point = StatusHistoryPoint(task=self.task, created_at=dt, status=status)
+        status_history_point.save()
+        status = _TaskStatus.SUBMITTED
+        status_history_point = StatusHistoryPoint(task=self.task, created_at=dt, status=status)
+        with self.assertRaises(IntegrityError):
+            status_history_point.save()
+
+    def test_save_with_invalid_task_status_choice_raises_error(self):
+        invalid_status_value = 414141
+        dt = timezone.now()
+        status_history_point = StatusHistoryPoint(created_at=dt, task=self.task, status=invalid_status_value)
+        with self.assertRaises(IntegrityError):
+            status_history_point.save()
+
+    def test_str_returns_status_history_point_description(self):
+        dt = timezone.now()
+        status = _TaskStatus.SUBMITTED
+        status_history_point = StatusHistoryPoint(task=self.task, created_at=dt, status=status)
+        self.assertEqual(f'{self.task.uuid}: {status.label}({dt.isoformat()})', str(status_history_point))
+
+    def test_deleting_referenced_task_deletes_status_history_point(self):
+        task = Task.objects.create(name='sample-task-2')
+        dt = timezone.now()
+        status = _TaskStatus.SUBMITTED
+        status_history_point = StatusHistoryPoint(task=task, created_at=dt, status=status)
+        task.delete()
+        with self.assertRaises(StatusHistoryPoint.DoesNotExist):
+            status_history_point.refresh_from_db()

--- a/schema-api/util/defaults.py
+++ b/schema-api/util/defaults.py
@@ -1,0 +1,20 @@
+"""
+This module contains functions that generate defaults for models' fields
+
+The purpose of a separate module and separate default providers lies to the particularity of Django default functions
+being persisted within the corresponding migration and ultimately getting used through their reference when the
+corresponding field value is missing. This causes an issue when trying to test the corresponding field that it indeed
+stores the default value of the function, by mocking the function - the mocking mocks the reference to the function but
+the Django model already uses the function as it is passed in the migration file, thus the mocking never takes place
+and the test fails.
+
+A work-around to this is to enclose these default providers to dummy wrappers that call these providers and return the
+corresponding value. The dummy wrapper will be stored in the generated migrations but the actual default provider is
+free to be mocked. The issue with this though is that the dummy wrapper cannot be erased, since this will break the
+migration that was generated for it.
+"""
+from django.utils import timezone
+
+
+def get_current_datetime():
+    return timezone.now()


### PR DESCRIPTION
Creation of a StatusHistoryPoint that will be used in the future to hold status changes for a task.

Implementation of the business logic that utilizes the StatusHistoryPoint will be provided at a later stage, since they depend on the definition of a custom migration step that takes old statuses, held within the Task model itself, passed on to the new model.