### PR TITLE
SCHEMA api changes for task status history, ability to cancel tasks, optional task name

### DIFF
--- a/schema-api/api/models.py
+++ b/schema-api/api/models.py
@@ -87,10 +87,6 @@ class Task(models.Model):
     class Meta:
         constraints = [
             CheckConstraint(
-                check=~Q(name__regex=r'^\s*$'),
-                name='name_not_empty',
-            ),
-            CheckConstraint(
                 check=Q(
                     submitted_at__lt=F('latest_update'),
                 ),

--- a/schema-api/api/models.py
+++ b/schema-api/api/models.py
@@ -76,12 +76,6 @@ class Task(models.Model):
                   'underlying TESK API for the task status'
     )
 
-    status = models.CharField(
-        choices=TaskStatus.choices,
-        default=TaskStatus.SUBMITTED,
-        help_text='Task status',
-        max_length=30
-    )
     submitted_at = models.DateTimeField(
         auto_now_add=True,
         help_text='Timestamp of task being approved and getting created'
@@ -95,27 +89,6 @@ class Task(models.Model):
             CheckConstraint(
                 check=~Q(name__regex=r'^\s*$'),
                 name='name_not_empty',
-            ),
-            CheckConstraint(
-                check=Q(status__in=[choice[0] for choice in TaskStatus.choices]),
-                name='status_enum'
-            ),
-            CheckConstraint(
-                check=Q(
-                    ~Q(task_id__regex=r'^\s*$') | Q(status=TaskStatus.SUBMITTED) | Q(status=TaskStatus.REJECTED) | Q(
-                        status=TaskStatus.APPROVED)),
-                name='scheduled_task_task_id_required'
-            ),
-            CheckConstraint(
-                check=Q(
-                    Q(
-                        Q(status=TaskStatus.CANCELED) | Q(status=TaskStatus.COMPLETED) |
-                        Q(status=TaskStatus.ERROR) | Q(status=TaskStatus.REJECTED), pending=False) |
-                    Q(
-                        ~Q(status=TaskStatus.CANCELED), ~Q(status=TaskStatus.COMPLETED),
-                        ~Q(status=TaskStatus.ERROR), ~Q(status=TaskStatus.REJECTED), pending=True),
-                ),
-                name='task_status_is_pending_integrity_check'
             ),
             CheckConstraint(
                 check=Q(
@@ -136,7 +109,7 @@ class Task(models.Model):
 
 class StatusHistoryPoint(models.Model):
 
-    task = models.ForeignKey(Task, on_delete=models.CASCADE)
+    task = models.ForeignKey(Task, on_delete=models.CASCADE, related_name='status_history_points')
     created_at = models.DateTimeField(default=get_current_datetime)
     status = models.IntegerField(choices=_TaskStatus.choices)
 

--- a/schema-api/api/models.py
+++ b/schema-api/api/models.py
@@ -141,7 +141,6 @@ class StatusHistoryPoint(models.Model):
     status = models.IntegerField(choices=_TaskStatus.choices)
 
     class Meta:
-        unique_together = ('task', 'status')
         constraints = [
             CheckConstraint(
                 check=Q(status__in=[choice.value for choice in _TaskStatus]),

--- a/schema-api/api/serializers.py
+++ b/schema-api/api/serializers.py
@@ -97,7 +97,7 @@ class StatusHistoryPointSerializer(serializers.Serializer):
 class TaskSerializer(BaseSerializer):
     context = serializers.CharField(source='context.name', read_only=True)
     uuid = serializers.UUIDField(read_only=True)
-    name = serializers.CharField()
+    name = serializers.CharField(required=False)
     description = serializers.CharField(required=False)
     status_history = StatusHistoryPointSerializer(many=True, read_only=True, source='status_history_points')
     submitted_at = serializers.DateTimeField(read_only=True)

--- a/schema-api/api/tests/test_models.py
+++ b/schema-api/api/tests/test_models.py
@@ -40,17 +40,8 @@ class StatusHistoryPointTestCase(TestCase):
         with self.assertRaises(IntegrityError):
             status_history_point.save()
 
-    def test_save_with_duplicate_referenced_task_works(self):
-        dt = timezone.now()
-        status = _TaskStatus.SUBMITTED
-        status_history_point = StatusHistoryPoint(task=self.task, created_at=dt, status=status)
-        status_history_point.save()
-        status = _TaskStatus.APPROVED
-        status_history_point = StatusHistoryPoint(task=self.task, created_at=dt, status=status)
-        status_history_point.save()
-
     def test_save_without_created_at_uses_timezone_now_default(self):
-        mocked_datetime = dt(2020, 1, 1, 1, 1, 1, tzinfo=datetime.UTC)
+        mocked_datetime = dt(2020, 1, 1, 1, 1, 1, tzinfo=datetime.timezone.utc)
         status = _TaskStatus.SUBMITTED
         with patch('django.utils.timezone.now', return_value=mocked_datetime):
             print(timezone.now())
@@ -73,16 +64,6 @@ class StatusHistoryPointTestCase(TestCase):
     def test_save_with_task_status_as_none_raises_error(self):
         dt = timezone.now()
         status_history_point = StatusHistoryPoint(created_at=dt, task=self.task, status=None)
-        with self.assertRaises(IntegrityError):
-            status_history_point.save()
-
-    def test_save_with_duplicate_task_status_for_same_task_raises_error(self):
-        dt = timezone.now()
-        status = _TaskStatus.SUBMITTED
-        status_history_point = StatusHistoryPoint(task=self.task, created_at=dt, status=status)
-        status_history_point.save()
-        status = _TaskStatus.SUBMITTED
-        status_history_point = StatusHistoryPoint(task=self.task, created_at=dt, status=status)
         with self.assertRaises(IntegrityError):
             status_history_point.save()
 

--- a/schema-api/api/urls.py
+++ b/schema-api/api/urls.py
@@ -1,7 +1,7 @@
 from django.urls import path
 
 from api.views import UserQuotasAPIView, TasksListCreateAPIView, TaskRetrieveAPIView, TaskStdoutAPIView, \
-    TaskStderrAPIView, UserContextInfoAPIView
+    TaskStderrAPIView, UserContextInfoAPIView, TaskCancelAPIView
 from api_auth.views import ContextsAPIView, ContextDetailsAPIView
 
 urlpatterns = [
@@ -9,6 +9,7 @@ urlpatterns = [
     path(r'tasks/<uuid:uuid>', TaskRetrieveAPIView.as_view(), name='tasks2'),
     path(r'tasks/<uuid:uuid>/stdout', TaskStdoutAPIView.as_view(), name='task_stdout'),
     path(r'tasks/<uuid:uuid>/stderr', TaskStderrAPIView.as_view(), name='task_stderr'),
+    path(r'tasks/<uuid:uuid>/cancel', TaskCancelAPIView.as_view(), name='task_cancel'),
     path(r'contexts', ContextsAPIView.as_view(), name='user-contexts'),
     path(r'contexts/<name>', ContextDetailsAPIView.as_view(), name='user-context-details'),
     # Temporary url - expected to be removed in the future

--- a/schema-api/api/views.py
+++ b/schema-api/api/views.py
@@ -389,7 +389,24 @@ class TaskRetrieveAPIView(RetrieveAPIView):
                             "uuid": "90cd67f2-eb3c-485a-a93f-0e99a573ded0",
                             "name": "task1.0",
                             "description": "test_task_description",
-                            "status": "RUNNING",
+                            "status_history": [
+                                {
+                                    "status": "SUBMITTED",
+                                    "updated_at": "2024-01-01T00:00:00.000000Z"
+                                },
+                                {
+                                    "status": "APPROVED",
+                                    "updated_at": "2024-01-01T00:00:01.000000Z"
+                                },
+                                {
+                                    "status": "SCHEDULED",
+                                    "updated_at": "2024-01-01T00:00:02.000000Z"
+                                },
+                                {
+                                    "status": "RUNNING",
+                                    "updated_at": "2024-01-01T00:00:03.000000Z"
+                                }
+                            ],
                             "submitted_at": "2023-03-03T06:58:54.426118Z",
                             "executors": [
                                 {
@@ -412,7 +429,24 @@ class TaskRetrieveAPIView(RetrieveAPIView):
                             "uuid": "90cd67f2-eb3c-485a-a93f-0e99a573ded0",
                             "name": "task1.0",
                             "description": "test_task_description",
-                            "status": "ERROR",
+                            "status_history": [
+                                {
+                                    "status": "SUBMITTED",
+                                    "updated_at": "2024-01-01T00:00:00.000000Z"
+                                },
+                                {
+                                    "status": "APPROVED",
+                                    "updated_at": "2024-01-01T00:00:01.000000Z"
+                                },
+                                {
+                                    "status": "SCHEDULED",
+                                    "updated_at": "2024-01-01T00:00:02.000000Z"
+                                },
+                                {
+                                    "status": "ERROR",
+                                    "updated_at": "2024-01-01T00:00:03.000000Z"
+                                }
+                            ],
                             "submitted_at": "2023-03-03T06:58:54.426118Z",
                             "executors": [
                                 {
@@ -435,7 +469,24 @@ class TaskRetrieveAPIView(RetrieveAPIView):
                             "uuid": "528d641d-e4ce-4c5b-8b69-aa6d42cf5d16",
                             "name": "hello world",
                             "description": "Complete example",
-                            "status": "COMPLETED",
+                            "status_history": [
+                                {
+                                    "status": "SUBMITTED",
+                                    "updated_at": "2024-01-01T00:00:00.000000Z"
+                                },
+                                {
+                                    "status": "APPROVED",
+                                    "updated_at": "2024-01-01T00:00:01.000000Z"
+                                },
+                                {
+                                    "status": "SCHEDULED",
+                                    "updated_at": "2024-01-01T00:00:02.000000Z"
+                                },
+                                {
+                                    "status": "COMPLETED",
+                                    "updated_at": "2024-01-01T00:00:03.000000Z"
+                                }
+                            ],
                             "submitted_at": "2023-03-06T14:02:52.146207Z",
                             "executors": [
                                 {

--- a/schema-api/util/serializers.py
+++ b/schema-api/util/serializers.py
@@ -29,6 +29,25 @@ class ModelMemberRelatedField(serializers.ListField):
         return whole_value
 
 
+class LatestInstanceRelatedField(serializers.Field):
+
+    def __init__(self, serializer_class, order_fields, reverse: bool = False, **kwargs):
+        super().__init__(**kwargs)
+        self.serializer_class = serializer_class
+        self.order_fields = order_fields
+
+    def to_representation(self, value):
+        latest_value = value.order_by(*self.order_fields).first()
+        return self.serializer_class(latest_value).data
+
+
+class IntegerChoiceField(serializers.IntegerField):
+
+    def to_representation(self, value):
+        serialized_integer = super(IntegerChoiceField, self).to_representation(value)
+        return ''
+
+
 class OmitEmptyValuesMixin:
 
     def to_representation(self, value: serializers.Serializer):


### PR DESCRIPTION
These changes:

- Utilize the previously defined StatusHistoryPoint relation in order to store in the database the recorded changes on the status history
- Provide a new endpoint that can be used to cancel a task
- Task name is now optional - one executor with an image and a command is the minimum amount of information that it is required